### PR TITLE
Warn when files can not be found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.5.0
+-----
+* Warn when specified files can not be found
+* Add option to turn off above warnings
+
 0.4.0
 -----
 * Accept more characters in env var keys

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "enw"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enw"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["ramn <github@rymdimperiet.org>"]
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "enw"
 version = "0.4.0"
 authors = ["ramn <github@rymdimperiet.org>"]
-edition = "2018"
+edition = "2021"
 
 description = "Similar to the GNU env command, but will automatically load an .env file, if found."
 license = "MIT/Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,7 +239,7 @@ impl OptionsBuilder {
                 .iter()
                 .map(|fname| fname.into()),
         );
-        let rest = matches.values_of_lossy("rest").unwrap_or_else(Vec::new);
+        let rest = matches.values_of_lossy("rest").unwrap_or_default();
         opt_builder.vars = rest
             .iter()
             .take_while(|x| x.contains('='))


### PR DESCRIPTION
Causes `enw` to warn when a specified file can not be found, printing the warning to `stderr`.

Adds the `--quiet` option for when you don't want to see the warnings.

Also upgrades to the 2021 edition.