### PR TITLE
chore: replace the rust builder action

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -8,6 +8,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - uses: icepuma/rust-action@master
+      - uses: rust-build/rust-build.action@v1.4.5
         with:
           args: cargo fmt -- --check && ./clippy.sh && cargo test --locked

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -10,4 +10,5 @@ jobs:
       - uses: actions/checkout@v1
       - uses: rust-build/rust-build.action@v1.4.5
         with:
+          RUSTTARGET: x86_64-unknown-linux-musl
           args: cargo fmt -- --check && ./clippy.sh && cargo test --locked


### PR DESCRIPTION
as the old one stopped working